### PR TITLE
Snap recipe for athena

### DIFF
--- a/snap/local/athena-monitor.sh
+++ b/snap/local/athena-monitor.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+[ -f $SNAP_COMMON/athena.default ] && . $SNAP_COMMON/athena.default
+
+monitor --config $SNAP_COMMON/athena-monitor.yaml $MONITOR_OPTS

--- a/snap/local/athena-processor.sh
+++ b/snap/local/athena-processor.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+[ -f $SNAP_COMMON/athena.default ] && . $SNAP_COMMON/athena.default
+
+processor --config $SNAP_COMMON/athena-processor.yaml $PROCESSOR_OPTS

--- a/snap/local/athena.default
+++ b/snap/local/athena.default
@@ -1,0 +1,8 @@
+# Default settings for athena. This file is sourced by /bin/sh from
+# athena.monitor.server and athena.processor.server.
+
+# Options to pass to athena.monitor
+MONITOR_OPTS=
+
+# Options to pass to athena.processor
+PROCESSOR_OPTS=

--- a/snap/local/install.hooks
+++ b/snap/local/install.hooks
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+[ -f $SNAP_COMMON/athena.default ] || cp $SNAP/athena.default $SNAP_COMMON/athena.default
+

--- a/snap/local/post-refresh.hooks
+++ b/snap/local/post-refresh.hooks
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+[ -f $SNAP_COMMON/athena.default ] || cp $SNAP/athena.default $SNAP_COMMON/athena.default
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,38 @@
+name: athena
+base: core20
+version: git
+summary: Simple files processor
+description: |
+  Athena provides a procesor and a monitor.
+
+grade: stable
+confinement: strict
+
+apps:
+  processor:
+    command: bin/athena-processor.sh
+    plugs: [network, network-bind]
+    daemon: simple
+
+  monitor:
+    command: bin/athena-monitor.sh
+    plugs: [network, network-bind]
+    daemon: simple
+
+parts:
+  snap-wrappers:
+    plugin: dump
+    source: snap/local/
+    organize:
+      athena-processor.sh: bin/athena-processor.sh
+      athena-monitor.sh: bin/athena-monitor.sh
+      install.hooks: snap/hooks/install
+      post-refresh.hooks: snap/hooks/post-refresh
+    prime:
+      - athena.default
+      - bin/*
+      - snap/hooks/*
+  athena:
+    plugin: go
+    source: ./
+    after: [snap-wrappers]


### PR DESCRIPTION
This patch snaps athena, the package installs the daemons athena.monitor
and athena.processor, both daemons will look for its configurations
under /var/snap/athena/common/ athena-monitor.yaml and athena-processor.yaml
respectively. To modify the flags passed to the program is possible to edit
/var/snap/athena/common/athena.defaults