### PR TITLE
Make db-path configurable and sf comment public

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,15 +13,17 @@ type Report struct {
 }
 
 type Subscriber struct {
-	Topic            string            `yaml:"topic"`
-	SFCommentEnabled bool              `yaml:"sf-comment-enabled"`
-	SFComment        string            `yaml:"sf-comment"`
-	Reports          map[string]Report `yaml:"reports"`
+	Topic             string            `yaml:"topic"`
+	SFCommentEnabled  bool              `yaml:"sf-comment-enabled"`
+	SFCommentIsPublic bool              `yaml:"sf-comment-public" default:"false"`
+	SFComment         string            `yaml:"sf-comment"`
+	Reports           map[string]Report `yaml:"reports"`
 }
 
 type Config struct {
 	Monitor struct {
 		APIKey       string   `yaml:"api-key"`
+		DBPath       string   `yaml:"db-path" default:"."`
 		PollEvery    string   `yaml:"poll-every" default:"5"`
 		Filetypes    []string `yaml:"filetypes"`
 		Directories  []string `yaml:"directories"`

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -267,7 +267,7 @@ func (s *BaseSubscriber) Handler(_ context.Context, file *common.File, msg *pubs
 		}
 
 		logrus.Debugf("Posting case comment (id: %s), body: %s", caseNumber, renderedComment)
-		comment := s.SalesforceClient.PostComment(sfCase.Id, renderedComment, true)
+		comment := s.SalesforceClient.PostComment(sfCase.Id, renderedComment, event.SFCommentIsPublic)
 		if comment == nil {
 			logrus.Errorf("Cannot post comment to case id: %s", sfCase.Id)
 			continue


### PR DESCRIPTION
Added the following configuration directives:

Processor:

* sf-comment-public: bool
* sf-comment-enabled: bool

Monitor:
* db-path: string

Signed-off-by: Jorge Niedbalski <jorge.niedbalski@canonical.com>