### PR TITLE
Prevent duplicate dispatches

### DIFF
--- a/pkg/common/files-com.go
+++ b/pkg/common/files-com.go
@@ -13,8 +13,10 @@ import (
 const DefaultFilesAgeDelta = 10 * time.Second
 
 type File struct {
-	Created time.Time `gorm:"autoCreateTime"` // Use unix seconds as creating time
-	Path    string    `gorm:"primary_key"`
+	Created      time.Time `gorm:"autoCreateTime"` // Use unix seconds as creating time
+	DispatchedAt time.Time
+	Dispatched   bool   `gorm:"default:false"`
+	Path         string `gorm:"primary_key"`
 }
 
 type FilesComClient interface {


### PR DESCRIPTION
* Added a field (dispatched, dispatched_at) to the db model.
* Prevent already dispatched file to be re-processed.

Signed-off-by: Jorge Niedbalski <jorge.niedbalski@canonical.com>