### PR TITLE
[snap] Build on arm64 and amd64 only

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,12 @@ description: |
 
 confinement: strict
 
+architectures:
+  - build-on: arm64
+    run-on: [ arm64 ]
+  - build-on: amd64
+    run-on: [ amd64 ]
+
 apps:
   processor:
     command: bin/athena-processor.sh


### PR DESCRIPTION
This change will make builds faster on build.snapcraft.io since these 2
architectures are the only ones we would care about, it's a win-win.