### PR TITLE
[snap] Include ovs-stat and hotsos in the snap

### DIFF
--- a/.github/workflows/snap-building.yaml
+++ b/.github/workflows/snap-building.yaml
@@ -1,0 +1,21 @@
+on: [push, pull_request]
+name: Build Snaps
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+      - name: Set outputs
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Replace snapcraft version/grade
+        run: sed -i -e "s/\$VERSION/${{ steps.vars.outputs.sha_short }}/g" snap/snapcraft.yaml
+      - name: Snapcraft Action
+        uses: samuelmeuli/action-snapcraft@v1.1.3
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v1
+        with:
+          use_lxd: true
+      - name: Build snap
+        run: sg lxd -c 'snapcraft --use-lxd'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,3 +35,6 @@ parts:
     plugin: go
     source: ./
     after: [snap-wrappers]
+    stage-snaps:
+      - hotsos/latest/stable
+      - ovs-stat/latest/stable


### PR DESCRIPTION
Adding ovs-stat and hotsos as 'stage-snaps' which will allow athena-core to run those.

To make sure the snaps building doesn't get broken added a gh workflow.