### PR TITLE
Remove -vvvv from hotsos runner

### DIFF
--- a/development-config.yaml
+++ b/development-config.yaml
@@ -50,7 +50,7 @@ processor:
                 #!/bin/bash
                 git clone --quiet https://github.com/dosaboy/hotsos.git {{basedir}}/hotsos &>/dev/null
                 tar -xf {{filepath}} -C {{basedir}} &>/dev/null
-                {{basedir}}/hotsos/hotsos.sh -s -a -vvvv {{basedir}}/$(basename {{filepath}} .tar.xz)/ &>/dev/null
+                {{basedir}}/hotsos/hotsos.sh -s -a {{basedir}}/$(basename {{filepath}} .tar.xz)/ &>/dev/null
                 cat *.summary
                 rm -f *.summary
                 exit 0


### PR DESCRIPTION
The -v* arg is not supported anymore.